### PR TITLE
fix(analytics): set default object value for properties parameter to prevent undefined exception.

### DIFF
--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -8,7 +8,7 @@ const s4 = () =>
 const guid = () => `${s4()}-${s4()}-${s4()}-${s4()}-${s4()}-${s4()}-${s4()}`;
 
 
-export const sendAnalyticEvent = (key, properties, shouldStringifyValue = true) => {
+export const sendAnalyticEvent = (key, properties = {}, shouldStringifyValue = true) => {
   let event = {
     key,
     properties,


### PR DESCRIPTION
This fixes calls to `sendAnalyticEvent` when no properties is passed, which was throwing an undefined exception.

This is now valid `sendAnalyticEvent('SomeEvent').then().catch()`
opposed to          `sendAnalyticEvent('SomeEvent', {}).then().catch()`

