### PR TITLE
docs(login-bridge): add documentation for zapp login and zapp player

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Promise - resolves:
 
 3. login user
 ```javascript
-NativeModules.ZappLogin.login(params);
+NativeModules.ZappLogin.login(additionalParams);
 ```
 parameters:
-`params: Object`
+`additionalParams: Object` - can be empty
 
 Returns:
 Promise - resolves:
@@ -124,7 +124,7 @@ NativeModules.ZappPlayer.playFullScreen(type, playable, configuration);
 parameters:
 `type: String`
 `playable: Object`
-`configuration: Object`
+`configuration: Object` - can be empty
 
 Returns:
 Promise - resolves:

--- a/README.md
+++ b/README.md
@@ -87,3 +87,45 @@ React-Native-Zapp-Bridge is a util package that enable you to:
       .catch(error);
   }
   ```
+
+### Zapp login
+1. import:
+```javascript
+import { NativeModules } from 'react-native';
+```
+2. check if user is logged in
+```javascript
+NativeModules.ZappLogin.isUserLoggedIn();
+```
+Returns:
+Promise - resolves:
+`{ isUserLoggedIn: bool }`
+
+3. login user
+```javascript
+NativeModules.ZappLogin.login(params);
+```
+parameters:
+`params: Object`
+
+Returns:
+Promise - resolves:
+`{ isUserLoggedIn: bool }`
+
+### Zapp player
+1. import:
+```javascript
+import { NativeModules } from 'react-native';
+```
+2. call player
+```javascript
+NativeModules.ZappPlayer.playFullScreen(type, playable, configuration);
+```
+parameters:
+`type: String`
+`playable: Object`
+`configuration: Object`
+
+Returns:
+Promise - resolves:
+`true`


### PR DESCRIPTION
## Description
Add documentation for Zapp login methods and Zapp player methods being used in the new VideoDetail component.

## Known Issues:
### Checklist for this pull request
- [x] PR is scoped to one task
- [ ] Tests included
- One of:
- [x] The PR is not making any UI change
- [ ] The PR is making a UI change but not a product change
- [ ] Screenshots included