### PR TITLE
fix: need to persist git for semantic release to work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ whitelist: &whitelist
     - README.md
     - .eslintrc
     - .babelrc
+    - .git
 
 version: 2
 jobs:


### PR DESCRIPTION
## Description:
When trying to (dry run) deploy `semantic-release` errors:
```[Semantic release]: ENOGITREPO Not running from a git repository.
The semantic-release command must be executed from a Git repository.

The current working directory is /home/circleci/repo.

Please verify your CI configuration to make sure the semantic-release command is executed from the root of the cloned repository.

{ AggregateError: 
    SemanticReleaseError: Not running from a git repository.
        at module.exports (/home/circleci/repo/node_modules/semantic-release/lib/get-error.js:6:10)
        at module.exports (/home/circleci/repo/node_modules/semantic-release/lib/verify.js:10:17)
        at <anonymous>
    at module.exports (/home/circleci/repo/node_modules/semantic-release/lib/verify.js:28:11)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7) name: 'AggregateError' }
Exited with code 1
```

This is an attempt to fix the above.

### Checklist for this pull request

* [x] PR is scoped to one task
* [x] Tests are included
* [x] Documentation included
* [x] One of:
  * [x] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change
    * [ ] Screenshots included

Thank you!
