### PR TITLE
build: remove dry run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
 
       - run:
           name: Semantic release
-          command: npx semantic-release --dry-run
+          command: npx semantic-release
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description:
`semantic-release` is now picking up the correct release number: https://circleci.com/gh/applicaster/React-Native-Zapp-Bridge/49
The following has information on how to do release candidates: https://github.com/semantic-release/semantic-release/issues/346#issuecomment-333229987
Whats stopping us fully enabling `semantic-release`?

### Checklist for this pull request

* [X] PR is scoped to one task
* [X] Tests are included
* [X] Documentation included
* [X] One of:
  * [X] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change
    * [ ] Screenshots included

Thank you!
