### PR TITLE
fix(build): missing index.js from repo whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ whitelist: &whitelist
     - package.json
     - package-lock.json
     - README.md
+    - index.js
     - .eslintrc
     - .babelrc
     - .git


### PR DESCRIPTION
## Description:
NPM module released without index.js. This fixes that.

* [X] PR is scoped to one task
* [X] Tests are included
* [X] Documentation included
* [X] One of:
  * [X] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change
    * [ ] Screenshots included

Thank you!
