### PR TITLE
feat: parse data_source_model on android

### DIFF
--- a/src/withZapp/index.js
+++ b/src/withZapp/index.js
@@ -8,7 +8,17 @@ const propParsers = {
     android: (val, props) =>
       JSON.parse(val)[props.is_tablet ? 'tablet' : 'smartphone']
   },
-  extra_props: { android: JSON.parse }
+  extra_props: {
+    android: val => {
+      const extraProps = JSON.parse(val);
+
+      if (extraProps.data_source_model) {
+        extraProps.data_source_model = JSON.parse(extraProps.data_source_model);
+      }
+
+      return extraProps;
+    }
+  }
 };
 
 const propsParser = (props, platform) =>

--- a/test/withZapp/withZapp.test.js
+++ b/test/withZapp/withZapp.test.js
@@ -29,7 +29,10 @@ describe('withZapp HOC', () => {
               tablet: { plat: 'tablet' },
               smartphone: { plat: 'smartphone' }
             }),
-            extra_props: JSON.stringify({})
+            extra_props: JSON.stringify({
+              foo: 'bar',
+              data_source_model: JSON.stringify({ double: 'stringified' })
+            })
           },
           'android'
         )
@@ -38,7 +41,10 @@ describe('withZapp HOC', () => {
         localization: {},
         settings: {},
         styles: { plat: 'smartphone' },
-        extra_props: {}
+        extra_props: {
+          foo: 'bar',
+          data_source_model: { double: 'stringified' }
+        }
       });
 
       expect(
@@ -72,7 +78,10 @@ describe('withZapp HOC', () => {
             localization: {},
             settings: {},
             styles: { plat: 'orig' },
-            extra_props: {}
+            extra_props: {
+              foo: 'bar',
+              data_source_model: { not: 'stringified' }
+            }
           },
           'ios'
         )
@@ -81,7 +90,10 @@ describe('withZapp HOC', () => {
         localization: {},
         settings: {},
         styles: { plat: 'orig' },
-        extra_props: {}
+        extra_props: {
+          foo: 'bar',
+          data_source_model: { not: 'stringified' }
+        }
       });
     });
   });


### PR DESCRIPTION
## Description:
Parse `data_source_model` contained within `extra_props` on android as it is double encoded.

### Checklist for this pull request

* [X] PR is scoped to one task
* [X] Tests are included
* [ ] Documentation included
* [X] One of:
  * [X] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change
    * [ ] Screenshots included

Thank you!
