### PR TITLE
Add onChange prop to ReactVideoView

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ import { APVideoPlayer } from 'react-native-zapp-bridge';
       this.playNextVideo()
     }
   };
+
+  /*
+  List of events you can receive from onChange
+
+  onVideoEnd
+  playerRemoved
+  
+  */
+  
  
   return <APVideoPlayer {...{ src, maxwidth, style }} onChange={onChange}/>;
 ```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ import { APVideoPlayer } from 'react-native-zapp-bridge';
   return <APVideoPlayer {...{ src, maxwidth, style }} onChange={onChange}/>;
 ```
 
+3.  onChange callback prop
+
+The onchange callback occurs when a native event of the video has been changed,
+it returns an object with the event information.
+
+Support events
+
+| Native Event | Description |
+| ------ | ------ |
+| onVideoEnd | The ended event occurs when the video has reached the end. |
+| playerRemoved | The playerRemoved occurs when the player is unmounted. |
+
+
+
 ### Data Source Plugin
 
 1.  import:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,16 @@ import { APVideoPlayer } from 'react-native-zapp-bridge';
     },
   };
 
-  return <APVideoPlayer {...{ src, maxwidth, style }} />;
+  // Example
+  const onChange = event => {
+    event.persist();
+
+    if (event.nativeEvent.eventName === 'onVideoEnd') {
+      this.playNextVideo()
+    }
+  };
+ 
+  return <APVideoPlayer {...{ src, maxwidth, style }} onChange={onChange}/>;
 ```
 
 ### Data Source Plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zapp-bridge",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/player/APVideoPlayer.js
+++ b/src/player/APVideoPlayer.js
@@ -74,12 +74,12 @@ const APVideoPlayer = ({
   }
 
   return (
-    <ReactVideoView 
-      src={src} 
-      style={[dims, styles.video, style]} 
+    <ReactVideoView
+      src={src}
+      style={[dims, styles.video, style]}
       onChange={onChange}
     />
-  );  
+  );
 };
 
 APVideoPlayer.propTypes = {
@@ -93,7 +93,8 @@ APVideoPlayer.propTypes = {
   }).isRequired,
   maxWidth: PropTypes.number,
   ratio: PropTypes.number,
-  style: ViewPropTypes.style
+  style: ViewPropTypes.style,
+  onChange: PropTypes.func,
 };
 
 APVideoPlayer.defaultProps = {

--- a/src/player/APVideoPlayer.js
+++ b/src/player/APVideoPlayer.js
@@ -53,7 +53,8 @@ const APVideoPlayer = ({
   src: { type, id, object, player_configuration, startTime, model },
   maxWidth,
   ratio,
-  style
+  style,
+  onChange
 }) => {
   const dims = getFrameDims(maxWidth, ratio);
 
@@ -72,7 +73,13 @@ const APVideoPlayer = ({
     src.id = parseInt(id, 10);
   }
 
-  return <ReactVideoView src={src} style={[dims, styles.video, style]} />;
+  return (
+    <ReactVideoView 
+      src={src} 
+      style={[dims, styles.video, style]} 
+      onChange={onChange}
+    />
+  );  
 };
 
 APVideoPlayer.propTypes = {


### PR DESCRIPTION
## Description: 

This will add the onChange prop to ReactVideoView in order to get the native events from the native player (onVideoEnd, playerRemoved).

## Known Issues: No way to receive events from the video player (video ends or player removed)

### Checklist for this pull request

* [✓ ] PR is scoped to one task
* [✓ ] Documentation included
* [ ] One of:
  * [ ✓] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change

Thank you!
