### PR TITLE
Stop stringifying analytics events for android by default.

### DIFF
--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { prop, assoc, __ } from 'ramda';
 import { postEvent } from './analytics';
 
@@ -12,7 +13,7 @@ const guid = () => `${s4()}-${s4()}-${s4()}-${s4()}-${s4()}-${s4()}-${s4()}`;
 export const sendAnalyticEvent = (
   key,
   properties = {},
-  shouldStringifyValue = true
+  shouldStringifyValue = Platform.select({ android: false, ios: true })
 ) => {
   /* eslint no-console: 0 */
   let event = {

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -15,23 +15,20 @@ export const sendAnalyticEvent = (
   properties = {},
   shouldStringifyValue = Platform.select({ android: false, ios: true })
 ) => {
-  /* eslint no-console: 0 */
-  let event = {
+  const event = {
     key,
     properties,
     id: properties.uuid || guid(),
     timestamp: Math.floor(Date.now() / 1000)
   };
-  if (shouldStringifyValue) {
-    event = JSON.stringify(event);
-  }
+
   const options = {
-    event
+    event: shouldStringifyValue ? JSON.stringify(event) : event
   };
 
   return getIp()
     .then(prop('ip'))
     .then(assoc('ip', __, options))
     .then(postEvent('MorpheusEvent'))
-    .catch(console.warn);
+    .catch(console.warn); // eslint-disable-line no-console
 };


### PR DESCRIPTION
## Description:
Android throws an exception if it receives a string as an event property for analytics. This PR changes default for android to unstringified object.

### Checklist for this pull request

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation included
* [x] One of:
  * [x] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change
    * [ ] Screenshots included

Thank you!
