### PR TITLE
chore(player): add shouldUnmount prop

### DIFF
--- a/src/player/APVideoPlayer.js
+++ b/src/player/APVideoPlayer.js
@@ -39,6 +39,7 @@ const APReactVideoView = {
       model: PropTypes.string
     }),
     onChange: PropTypes.func,
+    shouldUnmount: PropTypes.bool,
     maxWidth: PropTypes.string,
     ...ViewPropTypes
   }
@@ -54,7 +55,8 @@ const APVideoPlayer = ({
   maxWidth,
   ratio,
   style,
-  onChange
+  onChange,
+  shouldUnmount,
 }) => {
   const dims = getFrameDims(maxWidth, ratio);
 
@@ -77,6 +79,7 @@ const APVideoPlayer = ({
     <ReactVideoView
       src={src}
       style={[dims, styles.video, style]}
+      shouldUnmount={shouldUnmount}
       onChange={onChange}
     />
   );
@@ -95,11 +98,13 @@ APVideoPlayer.propTypes = {
   ratio: PropTypes.number,
   style: ViewPropTypes.style,
   onChange: PropTypes.func,
+  shouldUnmount: PropTypes.bool,
 };
 
 APVideoPlayer.defaultProps = {
   maxWidth: null,
-  ratio: 9 / 16
+  ratio: 9 / 16,
+  shouldUnmount: false
 };
 
 export default APVideoPlayer;


### PR DESCRIPTION
## Description:
This changes will add the prop shouldUnmount to the APReactVideoView component

## Known Issues:
In the RN side we don't have a way to unmount the player when switching between native and RN views this prop allow us to do this.

### Checklist for this pull request

* [x] PR is scoped to one task
* [ ] Tests are included
* [ ] Documentation included
* [ ] One of:
  * [x] The PR is not making any UI change
  * [ ] The PR is making a UI change but not a product change
    * [ ] Screenshots included

Thank you!
